### PR TITLE
Implement NavigationDatabase.close and use in cleanup

### DIFF
--- a/python_modules/interfaces/matlab_python_bridge.py
+++ b/python_modules/interfaces/matlab_python_bridge.py
@@ -402,6 +402,8 @@ def cleanup_bridge():
     
     if _waypoint_database:
         _waypoint_database.close()
+    if _nav_database:
+        _nav_database.close()
     
     _flight_plan_manager = None
     _nav_database = None

--- a/python_modules/nav_database/nav_data_manager.py
+++ b/python_modules/nav_database/nav_data_manager.py
@@ -101,6 +101,12 @@ class NavigationDatabase:
         # Create waypoints with basic fields only
         return [Waypoint(row[0], row[1], row[2], row[3], row[4]) for row in cursor.fetchall()]
 
+    def close(self):
+        """Close database connection"""
+        if self.connection:
+            self.connection.close()
+            self.connection = None
+
 if __name__ == "__main__":
     # Basic test when run directly
     db = NavigationDatabase()
@@ -112,3 +118,4 @@ if __name__ == "__main__":
         print(f"Found KSFO: {ksfo.latitude}, {ksfo.longitude}")
     else:
         print("KSFO not found")
+    db.close()

--- a/setup_fms_project.py
+++ b/setup_fms_project.py
@@ -26,6 +26,7 @@ def setup_fms_project():
         print(f"   ✓ Database contains {len(waypoints)} waypoints:")
         for wp in waypoints:
             print(f"     - {wp.identifier} ({wp.waypoint_type}): {wp.latitude:.4f}, {wp.longitude:.4f}")
+        nav_db.close()
     except Exception as e:
         print(f"   ✗ Navigation database setup failed: {e}")
         return False

--- a/tests/unit_tests/test_flight_plan_manager.py
+++ b/tests/unit_tests/test_flight_plan_manager.py
@@ -137,11 +137,12 @@ class TestFlightPlanManagerCoreState:
             nav_db.add_waypoint(wp)
         
         manager = FlightPlanManager(db_path)
-        
+
         yield manager
-        
+
         # Cleanup
         try:
+            nav_db.close()
             os.unlink(db_path)
         except:
             pass
@@ -210,8 +211,9 @@ class TestFlightPlanManagerNavigation:
         manager.set_active_plan(flight_plan)
         
         yield manager
-        
+
         try:
+            nav_db.close()
             os.unlink(db_path)
         except:
             pass
@@ -315,8 +317,9 @@ class TestFlightPlanManagerModification:
         manager.set_active_plan(flight_plan)
         
         yield manager
-        
+
         try:
+            nav_db.close()
             os.unlink(db_path)
         except:
             pass
@@ -403,8 +406,9 @@ class TestFlightPlanManagerFileOperations:
         plan2 = manager.create_flight_plan("PLAN2", "KOAK", "KSFO", ["SFO"])
         
         yield manager
-        
+
         try:
+            nav_db.close()
             os.unlink(db_path)
         except:
             pass
@@ -501,7 +505,8 @@ class TestFlightPlanManagerStatus:
         assert status["plan_name"] == "STATUS_TEST"
         assert status["current_leg_index"] == 0
         assert "total_waypoints" in status
-        
+
+        nav_db.close()
         os.unlink(db_path)
 
 class TestEdgeCases:
@@ -522,6 +527,7 @@ class TestEdgeCases:
         assert plan is not None
         assert len(plan.waypoints) == 2  # Just departure and arrival
         
+        nav_db.close()
         os.unlink(db_path)
     
     def test_nonexistent_waypoints(self):

--- a/tests/unit_tests/test_nav_database.py
+++ b/tests/unit_tests/test_nav_database.py
@@ -44,7 +44,7 @@ def test_navigation_database():
     print("All navigation database tests passed!")
     
     # Clean up test database
-    db.connection.close()
+    db.close()
     os.remove('test_nav.db')
     
     return True


### PR DESCRIPTION
## Summary
- add a `close` method to `NavigationDatabase`
- close the navigation DB in the MATLAB bridge cleanup
- ensure setup script closes the DB after initialization
- adjust unit tests to call `close()` during cleanup

## Testing
- `pytest -q` *(fails: Expected None vs return values etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685d62c0f6b8832ca7c2ecfdeefea604