### PR TITLE
Fix route optimizer import path

### DIFF
--- a/python_modules/flight_planning/route_optimizer.py
+++ b/python_modules/flight_planning/route_optimizer.py
@@ -11,7 +11,7 @@ import logging
 from typing import List, Optional, Tuple, Dict, Any
 from dataclasses import dataclass
 
-from flight_plan_manager import FlightPlan, FlightPlanWaypoint
+from .flight_plan_manager import FlightPlan, FlightPlanWaypoint
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- use a relative import for `FlightPlan` and `FlightPlanWaypoint`

## Testing
- `pytest -q` *(fails: AttributeError in `matlab_python_bridge` tests)*

------
https://chatgpt.com/codex/tasks/task_e_685d62c3dd84832cb6c4e6506ed743bf