### PR TITLE
Relocate test files

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ This will:
 python tests/test_nav_database.py
 
 # Test flight planning system  
-python tests/test_flight_planning.py
+python tests/unit_tests/python_modules/test_flight_planning.py
 ```
 
 ### 3. MATLAB Integration (Phase 5)

--- a/setup_fms_project.py
+++ b/setup_fms_project.py
@@ -141,7 +141,7 @@ def setup_fms_project():
     print()
     print("2. To test individual components:")
     print("   python tests/test_nav_database.py")
-    print("   python tests/test_flight_planning.py")
+    print("   python tests/unit_tests/python_modules/test_flight_planning.py")
     print()
     print("3. The navigation database is ready at: data/nav_database/navigation.db")
     print("4. Sample flight plans are saved in: data/flight_plans/")

--- a/tests/test_bridge_interactive.py
+++ b/tests/test_bridge_interactive.py
@@ -4,6 +4,13 @@
 Interactive test script for MATLAB Python Bridge
 """
 
+import sys
+import os
+
+sys.path.append(
+    os.path.join(os.path.dirname(__file__), '..')
+)
+
 from python_modules.interfaces.matlab_python_bridge import *
 
 def test_bridge_initialization():

--- a/tests/unit_tests/python_modules/test_flight_plan_manager.py
+++ b/tests/unit_tests/python_modules/test_flight_plan_manager.py
@@ -13,7 +13,13 @@ import sys
 import json
 
 # Add project modules to path
-sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.append(
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    )
+)
 
 from python_modules.flight_planning.flight_plan_manager import (
     FlightPlanManager, FlightPlan, FlightPlanWaypoint, create_flight_plan_manager

--- a/tests/unit_tests/python_modules/test_flight_planning.py
+++ b/tests/unit_tests/python_modules/test_flight_planning.py
@@ -7,7 +7,13 @@ import sys
 import os
 
 # Add project modules to path
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.append(
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    )
+)
 
 from python_modules.flight_planning.flight_plan_manager import FlightPlanManager
 from python_modules.nav_database.nav_data_manager import NavigationDatabase


### PR DESCRIPTION
## Summary
- move integration and unit tests to organized `tests` folders
- update path handling in moved tests
- reference new flight planning test path in docs and setup script

## Testing
- `pytest -q` *(fails: AttributeError: 'tuple' object has no attribute 'identifier')*

------
https://chatgpt.com/codex/tasks/task_e_685d72290844832c8bc8d9674aac936e