### PR TITLE
Add unit test for calculate_cross_track_error

### DIFF
--- a/.github/ISSUE_TEMPLATE/add_cross_track_error_test.md
+++ b/.github/ISSUE_TEMPLATE/add_cross_track_error_test.md
@@ -1,0 +1,12 @@
+---
+title: "Add unit tests for calculate_cross_track_error.m"
+labels: ["enhancement", "testing"]
+milestone: "Phase 3: Navigation Math"
+---
+
+## Summary
+Add MATLAB unit tests for `calculate_cross_track_error.m` ensuring correct sign and magnitude for on-track and off-track positions.
+
+## Acceptance Criteria
+- New test file `test_calculate_cross_track_error.m` covering on-track, left-of-course, and right-of-course scenarios.
+- Tests run with MATLAB's unit testing framework without errors.

--- a/tests/unit_tests/models/navigation/test_calculate_cross_track_error.m
+++ b/tests/unit_tests/models/navigation/test_calculate_cross_track_error.m
@@ -1,0 +1,20 @@
+function tests = test_calculate_cross_track_error
+    tests = functiontests(localfunctions);
+end
+
+function test_OnTrack(testCase)
+    xte = calculate_cross_track_error(0, 0.5, 0, 0, 0, 1);
+    testCase.verifyEqual(xte, 0, 'AbsTol', 1e-6);
+end
+
+function test_LeftOfCourse(testCase)
+    xte = calculate_cross_track_error(1, 0.5, 0, 0, 0, 1);
+    expected = -60.04046;
+    testCase.verifyEqual(xte, expected, 'AbsTol', 0.01);
+end
+
+function test_RightOfCourse(testCase)
+    xte = calculate_cross_track_error(-1, 0.5, 0, 0, 0, 1);
+    expected = 60.04046;
+    testCase.verifyEqual(xte, expected, 'AbsTol', 0.01);
+end


### PR DESCRIPTION
## Summary
- add MATLAB unit test for `calculate_cross_track_error`
- add issue template describing new test work

## Testing
- `pytest -q` *(fails: 'tuple' object has no attribute 'identifier')*

------
https://chatgpt.com/codex/tasks/task_e_685ea823172c832c9b80ef9e995abc75