### PR TITLE
Fix distance bearing test units

### DIFF
--- a/tests/unit_tests/models/navigation/test_calculate_distance_bearing.m
+++ b/tests/unit_tests/models/navigation/test_calculate_distance_bearing.m
@@ -13,14 +13,15 @@ function testBasicCalculation(testCase)
     % Test basic calculation with example inputs.
     %
     % For this test, we assume that moving from (0,0) to (1,0)
-    % yields an approximate distance of 111.195 km (for 1 degree latitude difference)
-    % and a bearing of 0 degrees (north).
+    % yields an approximate distance of 60.04 nautical miles
+    % (1 degree of latitude) and a bearing of 0 degrees (north).
     %
     % NOTE: These expected values are based on common approximations.
     % Adjust the expected values according to the actual implementation details
     % of calculate_distance_bearing.
 
-    expectedDistance = 111.195;  % approximate distance in kilometers
+    % Distance returned by calculate_distance_bearing is in nautical miles
+    expectedDistance = 60.04046;  % approximate distance in nautical miles
     expectedBearing  = 0;         % bearing in degrees (north)
 
     % Call the function under test.


### PR DESCRIPTION
## Summary
- update `test_calculate_distance_bearing` to use nautical miles

## Testing
- `pytest -q` *(fails: MATLAB bridge and integration tests require MATLAB environment)*

------
https://chatgpt.com/codex/tasks/task_e_685ed3d4fb60832ca592c200bfb45e77