### PR TITLE
Add airway and procedure datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ nearby = nav_db.find_waypoints_in_radius(37.6213, -122.3790, 50)  # 50nm radius
 
 # Get airway waypoints
 v334_waypoints = nav_db.get_airway_waypoints('V334')
+
+# Get procedure waypoints
+sid_wps = nav_db.get_procedure_waypoints('TEST_SID')
+star_wps = nav_db.get_procedure_waypoints('TEST_STAR')
 ```
 
 ## ✈️ Flight Planning System

--- a/python_modules/interfaces/matlab_python_bridge.py
+++ b/python_modules/interfaces/matlab_python_bridge.py
@@ -64,7 +64,7 @@ def search_waypoints_near_bridge(lat: float, lon: float, radius_nm: float = 50.0
     if not _waypoint_database:
         return []
     
-    waypoints = _waypoint_database.find_waypoints_in_radius(lat, lon, radius_nm)
+    results = _waypoint_database.find_waypoints_in_radius(lat, lon, radius_nm)
     return [
         {
             'identifier': wp.identifier,
@@ -74,9 +74,9 @@ def search_waypoints_near_bridge(lat: float, lon: float, radius_nm: float = 50.0
             'frequency': wp.frequency,
             'region': wp.region,
             'country': wp.country,
-            'distance_nm': _waypoint_database.calculate_distance(lat, lon, wp.latitude, wp.longitude)
+            'distance_nm': dist
         }
-        for wp in waypoints
+        for wp, dist in results
     ]
 
 def find_waypoints_by_type_bridge(waypoint_type: str) -> List[Dict[str, Any]]:

--- a/python_modules/nav_database/__init__.py
+++ b/python_modules/nav_database/__init__.py
@@ -1,2 +1,14 @@
+"""Navigation database package"""
 
-# Empty file to make it a Python package
+from .nav_data_manager import NavigationDatabase, Waypoint
+from .waypoint_database import WaypointDatabase
+from .airway_database import AirwayDatabase
+from .procedure_database import ProcedureDatabase
+
+__all__ = [
+    'NavigationDatabase',
+    'Waypoint',
+    'WaypointDatabase',
+    'AirwayDatabase',
+    'ProcedureDatabase'
+]

--- a/python_modules/nav_database/airway_database.py
+++ b/python_modules/nav_database/airway_database.py
@@ -1,0 +1,108 @@
+import sqlite3
+import os
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class AirwaySegment:
+    waypoint_id: str
+    sequence_order: int
+
+class AirwayDatabase:
+    """Manage airway database with segments"""
+
+    def __init__(self, db_path: str = 'data/nav_database/airways.db'):
+        self.db_path = db_path
+        self.connection = None
+        self.initialize_database()
+
+    def initialize_database(self):
+        db_dir = os.path.dirname(self.db_path) or '.'
+        os.makedirs(db_dir, exist_ok=True)
+        self.connection = sqlite3.connect(self.db_path)
+        cursor = self.connection.cursor()
+
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS airways (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL
+            )
+        ''')
+
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS airway_segments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                airway_id INTEGER,
+                waypoint_id TEXT NOT NULL,
+                sequence_order INTEGER NOT NULL,
+                FOREIGN KEY(airway_id) REFERENCES airways(id)
+            )
+        ''')
+
+        self.connection.commit()
+        self._insert_sample_data()
+
+    def _insert_sample_data(self):
+        cursor = self.connection.cursor()
+
+        # Airway V334
+        cursor.execute('INSERT OR IGNORE INTO airways (name) VALUES (?)', ('V334',))
+        cursor.execute('SELECT id FROM airways WHERE name=?', ('V334',))
+        v334_id = cursor.fetchone()[0]
+
+        v334_segments = [
+            (v334_id, 'SFO', 1),
+            (v334_id, 'WESLA', 2),
+            (v334_id, 'KOAK', 3)
+        ]
+        cursor.executemany('''
+            INSERT OR IGNORE INTO airway_segments (airway_id, waypoint_id, sequence_order)
+            VALUES (?, ?, ?)
+        ''', v334_segments)
+
+        # Additional airway V135
+        cursor.execute('INSERT OR IGNORE INTO airways (name) VALUES (?)', ('V135',))
+        cursor.execute('SELECT id FROM airways WHERE name=?', ('V135',))
+        v135_id = cursor.fetchone()[0]
+
+        v135_segments = [
+            (v135_id, 'SFO', 1),
+            (v135_id, 'CNDEL', 2),
+            (v135_id, 'KOAK', 3)
+        ]
+        cursor.executemany('''
+            INSERT OR IGNORE INTO airway_segments (airway_id, waypoint_id, sequence_order)
+            VALUES (?, ?, ?)
+        ''', v135_segments)
+
+        # Additional airway V200
+        cursor.execute('INSERT OR IGNORE INTO airways (name) VALUES (?)', ('V200',))
+        cursor.execute('SELECT id FROM airways WHERE name=?', ('V200',))
+        v200_id = cursor.fetchone()[0]
+
+        v200_segments = [
+            (v200_id, 'KOAK', 1),
+            (v200_id, 'REJOY', 2),
+            (v200_id, 'SFO', 3)
+        ]
+        cursor.executemany('''
+            INSERT OR IGNORE INTO airway_segments (airway_id, waypoint_id, sequence_order)
+            VALUES (?, ?, ?)
+        ''', v200_segments)
+
+        self.connection.commit()
+
+    def get_airway_waypoints(self, airway_name: str) -> List[str]:
+        cursor = self.connection.cursor()
+        cursor.execute('''
+            SELECT waypoint_id FROM airway_segments
+            JOIN airways ON airways.id = airway_segments.airway_id
+            WHERE airways.name = ?
+            ORDER BY sequence_order
+        ''', (airway_name,))
+        return [row[0] for row in cursor.fetchall()]
+
+    def close(self):
+        if self.connection:
+            self.connection.close()
+            self.connection = None

--- a/python_modules/nav_database/procedure_database.py
+++ b/python_modules/nav_database/procedure_database.py
@@ -1,0 +1,108 @@
+import sqlite3
+import os
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class ProcedureSegment:
+    waypoint_id: str
+    sequence_order: int
+
+class ProcedureDatabase:
+    """Manage standard procedure database"""
+
+    def __init__(self, db_path: str = 'data/nav_database/procedures.db'):
+        self.db_path = db_path
+        self.connection = None
+        self.initialize_database()
+
+    def initialize_database(self):
+        db_dir = os.path.dirname(self.db_path) or '.'
+        os.makedirs(db_dir, exist_ok=True)
+        self.connection = sqlite3.connect(self.db_path)
+        cursor = self.connection.cursor()
+
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS procedures (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                type TEXT NOT NULL
+            )
+        ''')
+
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS procedure_segments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                procedure_id INTEGER,
+                waypoint_id TEXT NOT NULL,
+                sequence_order INTEGER NOT NULL,
+                FOREIGN KEY(procedure_id) REFERENCES procedures(id)
+            )
+        ''')
+
+        self.connection.commit()
+        self._insert_sample_data()
+
+    def _insert_sample_data(self):
+        cursor = self.connection.cursor()
+        # SID procedure
+        cursor.execute('INSERT OR IGNORE INTO procedures (name, type) VALUES (?, ?)',
+                       ('TEST_SID', 'SID'))
+        cursor.execute('SELECT id FROM procedures WHERE name=?', ('TEST_SID',))
+        sid_id = cursor.fetchone()[0]
+        sid_segments = [
+            (sid_id, 'KSFO', 1),
+            (sid_id, 'SFO', 2),
+            (sid_id, 'WESLA', 3)
+        ]
+        cursor.executemany('''
+            INSERT OR IGNORE INTO procedure_segments (procedure_id, waypoint_id, sequence_order)
+            VALUES (?, ?, ?)
+        ''', sid_segments)
+
+        # STAR procedure
+        cursor.execute('INSERT OR IGNORE INTO procedures (name, type) VALUES (?, ?)',
+                       ('TEST_STAR', 'STAR'))
+        cursor.execute('SELECT id FROM procedures WHERE name=?', ('TEST_STAR',))
+        star_id = cursor.fetchone()[0]
+        star_segments = [
+            (star_id, 'KOAK', 1),
+            (star_id, 'REJOY', 2),
+            (star_id, 'SFO', 3),
+            (star_id, 'KSFO', 4)
+        ]
+        cursor.executemany('''
+            INSERT OR IGNORE INTO procedure_segments (procedure_id, waypoint_id, sequence_order)
+            VALUES (?, ?, ?)
+        ''', star_segments)
+
+        # Approach procedure
+        cursor.execute('INSERT OR IGNORE INTO procedures (name, type) VALUES (?, ?)',
+                       ('TEST_APP', 'APP'))
+        cursor.execute('SELECT id FROM procedures WHERE name=?', ('TEST_APP',))
+        app_id = cursor.fetchone()[0]
+        app_segments = [
+            (app_id, 'FAITH', 1),
+            (app_id, 'WESLA', 2),
+            (app_id, 'KSFO', 3)
+        ]
+        cursor.executemany('''
+            INSERT OR IGNORE INTO procedure_segments (procedure_id, waypoint_id, sequence_order)
+            VALUES (?, ?, ?)
+        ''', app_segments)
+        self.connection.commit()
+
+    def get_procedure_waypoints(self, name: str) -> List[str]:
+        cursor = self.connection.cursor()
+        cursor.execute('''
+            SELECT waypoint_id FROM procedure_segments
+            JOIN procedures ON procedures.id = procedure_segments.procedure_id
+            WHERE procedures.name = ?
+            ORDER BY sequence_order
+        ''', (name,))
+        return [row[0] for row in cursor.fetchall()]
+
+    def close(self):
+        if self.connection:
+            self.connection.close()
+            self.connection = None

--- a/python_modules/nav_database/waypoint_database.py
+++ b/python_modules/nav_database/waypoint_database.py
@@ -129,6 +129,14 @@ class WaypointDatabase:
         self.connection.commit()
         logger.info("Waypoint database tables and indexes created")
 
+    def calculate_distance(self, lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+        """Wrapper for distance calculation"""
+        return calculate_distance(lat1, lon1, lat2, lon2)
+
+    def calculate_bearing(self, lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+        """Wrapper for bearing calculation"""
+        return calculate_bearing(lat1, lon1, lat2, lon2)
+
     def add_waypoint(self, waypoint: Waypoint) -> bool:
         """Add or update a waypoint in the database"""
         try:

--- a/setup_fms_project.py
+++ b/setup_fms_project.py
@@ -8,6 +8,8 @@ Sets up the navigation database and creates sample flight plans
 import os
 import sys
 from python_modules.nav_database.nav_data_manager import NavigationDatabase
+from python_modules.nav_database.airway_database import AirwayDatabase
+from python_modules.nav_database.procedure_database import ProcedureDatabase
 from python_modules.flight_planning.flight_plan_manager import FlightPlanManager
 
 def setup_fms_project():
@@ -20,6 +22,11 @@ def setup_fms_project():
     try:
         nav_db = NavigationDatabase('data/nav_database/navigation.db')
         print("   ✓ Navigation database created successfully")
+
+        # Initialize airway and procedure databases
+        AirwayDatabase('data/nav_database/airways.db')
+        ProcedureDatabase('data/nav_database/procedures.db')
+        print("   ✓ Airways and procedures databases created")
         
         # List available waypoints
         waypoints = nav_db.list_all_waypoints()


### PR DESCRIPTION
## Summary
- expand sample waypoints in NavigationDatabase
- populate airway database with V135 and V200
- populate procedure database with TEST_STAR and TEST_APP
- update README usage example

## Testing
- `PYTHONPATH=. python tests/unit_tests/python_modules/test_nav_database.py`
- `PYTHONPATH=. python tests/unit_tests/python_modules/test_flight_planning.py`
- `PYTHONPATH=. python tests/test_waypoint_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_685f0c105070832cbb7016730a913cc0