### PR TITLE
Fix test imports and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ This will:
 ### 2. Test Individual Components
 ```bash
 # Test navigation database
-python tests/test_nav_database.py
+python tests/unit_tests/python_modules/test_nav_database.py
 
 # Test flight planning system  
 python tests/unit_tests/python_modules/test_flight_planning.py

--- a/setup_fms_project.py
+++ b/setup_fms_project.py
@@ -115,9 +115,8 @@ def setup_fms_project():
     print("3. Running System Tests...")
     
     # Import and run test modules
-    sys.path.append('tests')
-    from test_nav_database import test_navigation_database
-    from test_flight_planning import test_flight_planning
+    from tests.unit_tests.python_modules.test_nav_database import test_navigation_database
+    from tests.unit_tests.python_modules.test_flight_planning import test_flight_planning
     
     if test_navigation_database():
         print("   ✓ Navigation database tests passed")
@@ -140,7 +139,7 @@ def setup_fms_project():
     print("   >> test_matlab_python_bridge")
     print()
     print("2. To test individual components:")
-    print("   python tests/test_nav_database.py")
+    print("   python tests/unit_tests/python_modules/test_nav_database.py")
     print("   python tests/unit_tests/python_modules/test_flight_planning.py")
     print()
     print("3. The navigation database is ready at: data/nav_database/navigation.db")


### PR DESCRIPTION
## Summary
- remove unnecessary path tweaking when importing tests
- adjust instructions for running nav database test

## Testing
- `python setup_fms_project.py`
- `python -m tests.unit_tests.python_modules.test_nav_database`
- `python -m tests.unit_tests.python_modules.test_flight_planning`


------
https://chatgpt.com/codex/tasks/task_e_685f194d5030832c92c9f80979d5dc24